### PR TITLE
update URLs after repo moved to SNEWS2 org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build Documentation
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/latex-action@v3
         with:
           working_directory: doc
           root_file: documentation.tex

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -40,9 +40,9 @@ jobs:
   lint:
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ sntools was originally developed for Hyper-Kamiokande and later extended to supp
 
 Additionally, sntools can be used as a Python library that implements neutrino cross sections.
 
-This README file should give a brief overview over sntools and help you get started. For more information, see the [full documentation for each release on GitHub](https://github.com/JostMigenda/sntools/releases).
+This README file should give a brief overview over sntools and help you get started. For more information, see the [full documentation for each release on GitHub](https://github.com/SNEWS2/sntools/releases).
 
 ## Getting Started
 ### Installation Instructions
@@ -81,8 +81,8 @@ Water-based liquid scintillator, a mixture of the two materials, is also support
 A text file in the NUANCE format (used by the `/mygen/vecfile` options in WCSim) or the RATPAC format.
 
 ## Support and Contributing
-To report problems or ask for help, [open an issue on GitHub](https://github.com/JostMigenda/sntools/issues) or email the [lead developer](https://github.com/JostMigenda/).
+To report problems or ask for help, [open an issue on GitHub](https://github.com/SNEWS2/sntools/issues) or email the [lead developer](https://github.com/JostMigenda/).
 
-Contributions to sntools are welcome! See instructions in the [full documentation](https://github.com/JostMigenda/sntools/releases) for help on common ways to extend sntools (e. g. by adding a new detector, input format or interaction channel) and please submit a pull request with your contributions!
+Contributions to sntools are welcome! See instructions in the [full documentation](https://github.com/SNEWS2/sntools/releases) for help on common ways to extend sntools (e. g. by adding a new detector, input format or interaction channel) and please submit a pull request with your contributions!
 
 Please note that this project is released with a Contributor Code of Conduct (see `CODE_OF_CONDUCT.md`). By participating in this project you agree to abide by its terms.

--- a/doc/documentation.tex
+++ b/doc/documentation.tex
@@ -35,7 +35,7 @@
 \newcommand{\nuxbar}{\ensuremath{\bar{\nu}_x}\xspace}
 
 
-\title{Documentation for sntools 1.3\footnote{See \url{https://github.com/JostMigenda/sntools} for the most recent version.}}
+\title{Documentation for sntools 1.3\footnote{See \url{https://github.com/SNEWS2/sntools} for the most recent version.}}
 \author{Jost Migenda\footnote{King’s College London, \url{jost.migenda@kcl.ac.uk}}}
 \date{\today}
 
@@ -303,7 +303,7 @@ sntools also supports the following flavour transformations, which are implement
 See reference~\cite{SNEWS:2021ezc} for a full description.
 To use these transformations in sntools, prefix them with \texttt{SNEWPY-}. For example, to apply three flavor decoherence use sntools with the command line argument \texttt{--transformation SNEWPY-ThreeFlavorDecoherence}.
 
-Some additional flavour transformations, like \texttt{NeutrinoDecay}, are implemented in SNEWPY but require some more work to be supported by sntools. If you are interested in these, \href{https://github.com/JostMigenda/sntools/issues/28}{please join the discussion on GitHub}!
+Some additional flavour transformations, like \texttt{NeutrinoDecay}, are implemented in SNEWPY but require some more work to be supported by sntools. If you are interested in these, \href{https://github.com/SNEWS2/sntools/issues/28}{please join the discussion on GitHub}!
 
 
 \subsection{Input Formats} \label{sec:input-formats}
@@ -398,7 +398,7 @@ Finally, a linear interpolation in time and log cubic spline interpolation in en
 
 \section{Getting Help and Contributing}
 
-To report problems or ask for help, \href{https://github.com/JostMigenda/sntools/issues}{open an issue on GitHub} or email the lead developer (see title page of this document).
+To report problems or ask for help, \href{https://github.com/SNEWS2/sntools/issues}{open an issue on GitHub} or email the lead developer (see title page of this document).
 
 sntools is designed to be versatile and support many different detectors and input formats.
 \textbf{Your contributions are welcome!}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "numpy",
     "scipy",
     "h5py >= 2.10",
-    "snewpy ~=1.4b1",
+    "snewpy ~=1.4.0",
     "uproot"
 ]
 
@@ -39,6 +39,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ sntools = "sntools.genevts:main"
 
 
 [project.urls]
-"Homepage" = "https://github.com/JostMigenda/sntools"
-"Bug Tracker" = "https://github.com/JostMigenda/sntools/issues"
+"Homepage" = "https://github.com/SNEWS2/sntools"
+"Bug Tracker" = "https://github.com/SNEWS2/sntools/issues"
 
 
 [tool.setuptools.dynamic]

--- a/src/sntools/__init__.py
+++ b/src/sntools/__init__.py
@@ -10,7 +10,7 @@ support different detectors and detector materials.
 
 For usage information, run `sntools -h` or `python sntools/genevts.py -h`.
 For more extensive documentation, to report issues or to contribute code,
-see https://github.com/JostMigenda/sntools.
+see https://github.com/SNEWS2/sntools.
 """
 __version__ = '1.3'
 
@@ -28,7 +28,7 @@ def setup():
 
     flux_dir = 'fluxes/'
     flux_file = flux_dir + 'intp2001.data'
-    flux_url = 'https://raw.githubusercontent.com/JostMigenda/sntools/main/fluxes/intp2001.data'
+    flux_url = 'https://raw.githubusercontent.com/SNEWS2/sntools/main/fluxes/intp2001.data'
     if os.path.exists(flux_file):
         tryprint(u"\u2705", "[SUCCESS]")
         print("Using sample flux file at " + flux_file)
@@ -68,7 +68,7 @@ def setup():
         tryprint(u"\u274c", "[ERROR]")
         print("Please ensure you have installed the most recent version of sntools and all dependencies.")
         tryprint(u"\u274c", "[ERROR]")
-        print("If this persists, please go to https://github.com/JostMigenda/sntools and open a new issue.")
+        print("If this persists, please go to https://github.com/SNEWS2/sntools and open a new issue.")
 
 
 def tryprint(default, alternative=''):


### PR DESCRIPTION
The old URLs [should redirect automatically](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository), but it’s better to update URLs to avoid confusion.