### PR TITLE
JUNO: don’t write secondary file in verbose mode

### DIFF
--- a/src/sntools/genevts.py
+++ b/src/sntools/genevts.py
@@ -48,27 +48,28 @@ def main():
 
     # Sort events by time and write them to an output file
     events.sort(key=lambda evt: evt.time)
-    with open(args.output, "w") as outfile:
-        if args.verbose:  # write parameters to file as a comment
-            outfile.write(f"# Generated on {datetime.now()} with the options:\n")
-            outfile.write(f"# {args}\n")
-        if args.mcformat == 'NUANCE':
-            for (i, evt) in enumerate(events):
-                evt.vertex = args.detector.generate_random_vertex()
-                outfile.write(evt.nuance_string(i))
-            outfile.write("$ stop\n")
-        if args.mcformat == 'RATPAC':
-            for (i, evt) in enumerate(events):
-                evt.vertex = args.detector.generate_random_vertex()
-                outfile.write(evt.ratpac_string(i, events))
-        if args.mcformat == 'ROOT_JUNO':
-            fname =	args.output+".root"
-            root_outfile = uproot.recreate(fname)
-            root_outfile.mktree("SNEvents",{"nparticles": "uint64", "origPDGID":"int32", "nuE":"double", "pdgid": ("int32",(2,)),"t": ("float64",(2,)),
-                                            "px": ("float64",(2,)),"py":("float64",(2,)),"pz":("float64",(2,)),"m":("float64",(2,)), "channel": "int64"})
-            for (i, evt) in enumerate(events):
-                evt.vertex = args.detector.generate_random_vertex()
-                evt.juno_string(i, root_outfile)
+    if args.mcformat in ('NUANCE', 'RATPAC'):
+        with open(args.output, "w") as outfile:
+            if args.verbose:  # write parameters to file as a comment
+                outfile.write(f"# Generated on {datetime.now()} with the options:\n")
+                outfile.write(f"# {args}\n")
+            if args.mcformat == 'NUANCE':
+                for (i, evt) in enumerate(events):
+                    evt.vertex = args.detector.generate_random_vertex()
+                    outfile.write(evt.nuance_string(i))
+                outfile.write("$ stop\n")
+            if args.mcformat == 'RATPAC':
+                for (i, evt) in enumerate(events):
+                    evt.vertex = args.detector.generate_random_vertex()
+                    outfile.write(evt.ratpac_string(i, events))
+    if args.mcformat == 'ROOT_JUNO':
+        fname =	args.output+".root"
+        root_outfile = uproot.recreate(fname)
+        root_outfile.mktree("SNEvents",{"nparticles": "uint64", "origPDGID":"int32", "nuE":"double", "pdgid": ("int32",(2,)),"t": ("float64",(2,)),
+                                        "px": ("float64",(2,)),"py":("float64",(2,)),"pz":("float64",(2,)),"m":("float64",(2,)), "channel": "int64"})
+        for (i, evt) in enumerate(events):
+            evt.vertex = args.detector.generate_random_vertex()
+            evt.juno_string(i, root_outfile)
 
 def parse_command_line_options():
     """Define and parse command line options."""

--- a/src/sntools/genevts.py
+++ b/src/sntools/genevts.py
@@ -48,6 +48,9 @@ def main():
 
     # Sort events by time and write them to an output file
     events.sort(key=lambda evt: evt.time)
+    for evt in events:
+        evt.vertex = args.detector.generate_random_vertex()
+
     if args.mcformat in ('NUANCE', 'RATPAC'):
         with open(args.output, "w") as outfile:
             if args.verbose:  # write parameters to file as a comment
@@ -55,12 +58,10 @@ def main():
                 outfile.write(f"# {args}\n")
             if args.mcformat == 'NUANCE':
                 for (i, evt) in enumerate(events):
-                    evt.vertex = args.detector.generate_random_vertex()
                     outfile.write(evt.nuance_string(i))
                 outfile.write("$ stop\n")
             if args.mcformat == 'RATPAC':
                 for (i, evt) in enumerate(events):
-                    evt.vertex = args.detector.generate_random_vertex()
                     outfile.write(evt.ratpac_string(i, events))
     if args.mcformat == 'ROOT_JUNO':
         fname =	args.output+".root"
@@ -68,7 +69,6 @@ def main():
         root_outfile.mktree("SNEvents",{"nparticles": "uint64", "origPDGID":"int32", "nuE":"double", "pdgid": ("int32",(2,)),"t": ("float64",(2,)),
                                         "px": ("float64",(2,)),"py":("float64",(2,)),"pz":("float64",(2,)),"m":("float64",(2,)), "channel": "int64"})
         for (i, evt) in enumerate(events):
-            evt.vertex = args.detector.generate_random_vertex()
             evt.juno_string(i, root_outfile)
 
 def parse_command_line_options():


### PR DESCRIPTION
Previously, in verbose mode sntools would write the timestamp and parameters to the filename `args.output`. For NUANCE and RATPAC files, it would then write events to the same file; for JUNO, it would write them to a separate file (with an additional `.root` suffix).

Since it doesn’t make much sense to have these parameters in a different file than the actual events, this PR avoids writing the parameters file.

@mcolomermolla Do you think it’s worth adding a separate tree with that metadata to the root files? (I occasionally found it useful when trying things out; for production use it’s unnecessary, since there will be other mechanisms to handle this bookkeeping.)