### PR TITLE
Basic support for SNEWPY v1.5

### DIFF
--- a/doc/documentation.tex
+++ b/doc/documentation.tex
@@ -314,7 +314,9 @@ This section will briefly describe each format and the processing steps necessar
 In addition, sntools supports the following input formats, which are implemented by SNEWPY~\cite{Baxter2021,SNEWS:2021ezc}:
 \texttt{Bollig\_2016},
 \texttt{Fornax\_2021},
+\texttt{Fornax\_2022},
 \texttt{Kuroda\_2020},
+\texttt{Mori\_2023},
 \texttt{Nakazato\_2013},
 \texttt{OConnor\_2015},
 \texttt{Sukhbold\_2015},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "numpy",
     "scipy",
     "h5py >= 2.10",
-    "snewpy ~=1.4.0",
+    "snewpy ~=1.5.0",
     "uproot"
 ]
 

--- a/src/sntools/formats/__init__.py
+++ b/src/sntools/formats/__init__.py
@@ -162,7 +162,7 @@ class SNEWPYCompositeFlux(CompositeFlux):
 
         # snewpy.models.loaders classes treat relative file paths as relative to the snewpy cache directory,
         # so we’ll turn it into an absolute path first.
-        sn_model = getattr(import_module('snewpy.models.loaders'), format)(abspath(file))
+        sn_model = getattr(import_module('snewpy.models.ccsn_loaders'), format)(abspath(file))
 
         for flv in ('e', 'eb', 'x', 'xb'):
             f = SNEWPYFlux(sn_model, flv, starttime, endtime)

--- a/src/sntools/genevts.py
+++ b/src/sntools/genevts.py
@@ -77,7 +77,9 @@ def parse_command_line_options():
     parser.add_argument("input_file", help="Name or common prefix of the input file(s). Required.")
 
     choices = ("gamma", "nakazato", "princeton", "totani", "warren2020",
-               "SNEWPY-Bollig_2016", "SNEWPY-Fornax_2021", "SNEWPY-Kuroda_2020", "SNEWPY-Nakazato_2013", "SNEWPY-OConnor_2015", "SNEWPY-Sukhbold_2015", "SNEWPY-Tamborra_2014", "SNEWPY-Walk_2018", "SNEWPY-Walk_2019", "SNEWPY-Zha_2021")
+               "SNEWPY-Bollig_2016", "SNEWPY-Fornax_2021", "SNEWPY-Fornax_2022", "SNEWPY-Kuroda_2020",
+               "SNEWPY-Mori_2023", "SNEWPY-Nakazato_2013", "SNEWPY-OConnor_2015", "SNEWPY-Sukhbold_2015",
+               "SNEWPY-Tamborra_2014", "SNEWPY-Walk_2018", "SNEWPY-Walk_2019", "SNEWPY-Zha_2021")
     parser.add_argument("-f", "--format", metavar="FORMAT", choices=choices, default=choices[1],
                         help="Format of input file(s). Choices: %(choices)s. Default: %(default)s.")
 


### PR DESCRIPTION
This adds basic support for SNEWPY v1.5, including for the new `Fornax_2022` and `Mori_2023` models. In particular, it fixes #55.

No support for preSN models yet; that will require a few more changes and extensive testing, so I’ll leave it for the next release.